### PR TITLE
fixed routing for /profile

### DIFF
--- a/src/OnePager/Router.js
+++ b/src/OnePager/Router.js
@@ -183,7 +183,7 @@ const Routes = () => (
         {/* <PrivateRoute path="/profile" component={Profile} /> */}
         {/* commenting out and changing value of component
          just to give me access to MyProfile */}
-        <PrivateRoute path="/profile" component={MyProfile} />
+        <PrivateRoute path="/profile" component={Profile} />
         <PrivateRoute path="/myprofile" component={MyProfile} />
 
         <PrivateRoute path="/getaccess" component={GetAccess} />


### PR DESCRIPTION
component MyProfile was being displayed at both /profile and /myProfile. I changed it so that the Profile component is displayed at /profile and the MyProfile component is displayed at /myprofile