### PR TITLE
Make sure infinite loop of requests to lambda function won't happen

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -232,6 +232,8 @@ export default class Home extends React.Component {
         }).catch(err => {
           console.log(err)
         });
+    } else {
+      this.setState({ user: { requests: 1 } })
     }
 
 


### PR DESCRIPTION
Resolving issues with infinite loop of requests to get-all-films lambda function by setting the request count to 1 even when the user is not authenticated.