### PR TITLE
add explore button to home page

### DIFF
--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -267,6 +267,9 @@ export default class Home extends React.Component {
                   </p><br />
                   <p>{this.state.sponsorshipLabel}</p>
                 </div>
+                <div> 
+                  <a href="/explore">Explore</a>
+                </div>
                 <div className="film-lists">
                   {filmGroups.map((group, index) => (
                     <FilmCat


### PR DESCRIPTION
## Description
There are many ways to add a button that leads to a page. We can make a `<button>` tag redirect to a page by using the `onClick` attribute, or we can just have an `<a>` tag and style it to make it look like a button. This pull request is intended for the second approach by adding an `<a>` tag that links to the explore page.

**Fixes #276 **


## Changes proposed in this pull request

1. Add a link that directs to the explore page
1.
1.
1.
1.


## How have changes been tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [ ] used testing framework (like JEST)
- [x] used browser dev tool (console tab)
- [x] any other method for testing
Clicked on it to see if it works.


## Important code snipts
Please add code snipts for reviewer to pay attention
> code snipt 1: can be typed here...

> code snipt 2: can be typed here... 

> code snipt 3: can be typed here...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have tested changes for browser compatibility.
- [x] My changes will work on mobile screens as well as on desktop screens

## Mention people or team for reviewing propsed changes

@Nechir-89 
